### PR TITLE
Add Python automatic task scheduler example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# clone
+# Gestionnaire de tâches automatique
+
+Ce dépôt contient un petit exemple de planificateur de tâches écrit en Python.
+
+## Fichiers
+
+- `auto_task_planner.py` : script principal qui charge les tâches décrites dans `tasks.json` et les exécute après un délai défini.
+- `tasks.json` : exemple de liste de tâches avec un délai en secondes.
+
+## Utilisation
+
+```bash
+python auto_task_planner.py
+```
+
+Modifiez `tasks.json` pour ajouter ou supprimer des tâches en précisant le texte à afficher et le délai avant exécution.

--- a/auto_task_planner.py
+++ b/auto_task_planner.py
@@ -1,0 +1,37 @@
+import json
+import sched
+import time
+from datetime import datetime
+
+
+def load_tasks(file_path="tasks.json"):
+    with open(file_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def schedule_tasks(tasks):
+    scheduler = sched.scheduler(time.time, time.sleep)
+
+    for task in tasks:
+        delay = task.get("delay", 0)
+        name = task.get("task", "Unnamed task")
+
+        def task_action(task_name=name):
+            print(f"{datetime.now().isoformat(timespec='seconds')} - Executing: {task_name}")
+
+        scheduler.enter(delay, 1, task_action)
+
+    print("Starting task scheduler. Press Ctrl+C to exit.")
+    try:
+        scheduler.run()
+    except KeyboardInterrupt:
+        print("Scheduler stopped.")
+
+
+def main():
+    tasks = load_tasks()
+    schedule_tasks(tasks)
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks.json
+++ b/tasks.json
@@ -1,0 +1,4 @@
+[
+  {"task": "Sauvegarde de la base de données", "delay": 5},
+  {"task": "Envoi du rapport", "delay": 10}
+]


### PR DESCRIPTION
## Summary
- add `auto_task_planner.py` for a basic scheduler using `sched`
- add `tasks.json` with example tasks
- update `README.md` in French with usage instructions

## Testing
- `python auto_task_planner.py & sleep 12; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_6885607804d883268de9aac2e0bcff1f